### PR TITLE
add support for extending the cycle counter to u64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - CI changelog entry enforcer
+- New feature `extend` to track DWT cycle counter overflows and extend
+  the range to `u64`.
 
 ## [v1.0.0] - 2021-12-25
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ extend = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cortex-m = "0.7"
+cortex-m = "0.7.4"
 rtic-monotonic = "1.0.0"
 fugit = "0.3.0"
 cfg-if = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.0.0"
 authors = [
   "The Real-Time Interrupt-driven Concurrency developers",
   "Emil Fresk <emil.fresk@gmail.com>",
+  "Robert Jördens <rj@quartiq.de>",
 ]
 categories = ["concurrency", "embedded", "no-std"]
 description = "RTIC Monotonic implemenation based on Systick and DWT"
@@ -15,9 +16,13 @@ edition = "2021"
 [lib]
 name = "dwt_systick_monotonic"
 
+[features]
+extend = []
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 cortex-m = "0.7"
 rtic-monotonic = "1.0.0"
 fugit = "0.3.0"
+cfg-if = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,11 @@
 #![no_std]
 
 use cortex_m::peripheral::{syst::SystClkSource, DCB, DWT, SYST};
-pub use fugit::{self, ExtU32, ExtU64};
+pub use fugit;
+#[cfg(not(feature = "extend"))]
+pub use fugit::ExtU32;
+#[cfg(feature = "extend")]
+pub use fugit::ExtU64;
 use rtic_monotonic::Monotonic;
 
 /// DWT and Systick combination implementing `rtic_monotonic::Monotonic`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,11 @@ impl<const TIMER_HZ: u32> Monotonic for DwtSystick<TIMER_HZ> {
 
     #[inline(always)]
     fn clear_compare_flag(&mut self) {
-        // NOOP with SysTick interrupt
+        // Set a long reload in case `set_compare()` is not called again.
+        #[cfg(feature = "extend")]
+        self.systick.set_reload(0xff_ffff);
+        #[cfg(feature = "extend")]
+        self.systick.clear_current();
     }
 
     #[cfg(feature = "extend")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,7 @@ impl<const TIMER_HZ: u32> DwtSystick<TIMER_HZ> {
     #[inline(always)]
     pub fn new(dcb: &mut DCB, dwt: DWT, systick: SYST, sysclk: u32) -> Self {
         assert!(TIMER_HZ == sysclk);
+        assert!(DWT::has_cycle_counter());
 
         dcb.enable_trace();
         DWT::unlock();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,9 @@ use rtic_monotonic::Monotonic;
 ///
 /// Note that the SysTick interrupt must not be disabled longer than half the
 /// cycle counter overflow period (typically a couple seconds).
+///
+/// When the `extend` feature is enabled, the cycle counter width is extended to
+/// `u64` by detecting and counting overflows.
 pub struct DwtSystick<const TIMER_HZ: u32> {
     dwt: DWT,
     systick: SYST,
@@ -76,7 +79,7 @@ impl<const TIMER_HZ: u32> Monotonic for DwtSystick<TIMER_HZ> {
                 let now = self.dwt.cyccnt.read();
 
                 // Detect CYCCNT overflow
-                if now.wrapping_sub(low) >= 1 << 31 {
+                if now < low {
                     high = high.wrapping_add(1);
                 }
                 self.last = ((high as u64) << 32) | (now as u64);


### PR DESCRIPTION
This enables tracking time intervals of more than a couple seconds on
modern processors.
Tested on hardware (stm32h743, 400 MHz, https://github.com/quartiq/stabilizer) with spawn across overflows.